### PR TITLE
Add admin-secured book management endpoints

### DIFF
--- a/src/main/java/com/api/libreria/controller/BookController.java
+++ b/src/main/java/com/api/libreria/controller/BookController.java
@@ -30,4 +30,39 @@ public class BookController {
         Book saved = bookRepository.save(request);
         return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Book> getBook(@PathVariable Long id) {
+        return bookRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Book> updateBook(@PathVariable Long id,
+                                           @Valid @RequestBody Book request) {
+        Book existing = bookRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Libro no encontrado"));
+
+        existing.setTitle(request.getTitle());
+        existing.setAuthor(request.getAuthor());
+        existing.setEditorial(request.getEditorial());
+        existing.setCategory(request.getCategory());
+        existing.setPrice(request.getPrice());
+        existing.setStock(request.getStock());
+        existing.setDescription(request.getDescription());
+        existing.setImageUrl(request.getImageUrl());
+
+        Book updated = bookRepository.save(existing);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteBook(@PathVariable Long id) {
+        bookRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
 }


### PR DESCRIPTION
## Summary
- add CRUD endpoints for individual books
- secure book management endpoints for admins only

## Testing
- `./mvnw -q test` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685371bc6580832595f07a1cac4d84af