### PR TITLE
Add authenticated user profile endpoint

### DIFF
--- a/src/main/java/com/api/libreria/controller/UserController.java
+++ b/src/main/java/com/api/libreria/controller/UserController.java
@@ -3,12 +3,14 @@ package com.api.libreria.controller;
 import com.api.libreria.model.User;
 import com.api.libreria.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping({"/api/users", "/api/usuarios"})
 public class UserController {
 
     private final UserService userService;
@@ -38,5 +40,12 @@ public class UserController {
     public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/perfil")
+    public ResponseEntity<User> getProfile(@AuthenticationPrincipal UserDetails userDetails) {
+        return userService.getUserByUsername(userDetails.getUsername())
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/com/api/libreria/service/UserService.java
+++ b/src/main/java/com/api/libreria/service/UserService.java
@@ -24,6 +24,10 @@ public class UserService {
         return userRepository.findById(id);
     }
 
+    public Optional<User> getUserByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
+
     public User saveUser(User user) {
         return userRepository.save(user);
     }


### PR DESCRIPTION
## Summary
- expand `UserController` mapping to allow `/api/usuarios` routes
- add profile endpoint returning the authenticated user
- expose service method to fetch user by username

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685371bd5f448325a175df4383e189e4