### PR TITLE
Add Oferta entity and API endpoints

### DIFF
--- a/src/main/java/com/api/libreria/controller/OfertaController.java
+++ b/src/main/java/com/api/libreria/controller/OfertaController.java
@@ -1,0 +1,74 @@
+package com.api.libreria.controller;
+
+import com.api.libreria.model.Oferta;
+import com.api.libreria.service.OfertaService;
+import org.springframework.http.*;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ofertas")
+public class OfertaController {
+
+    private final OfertaService ofertaService;
+
+    public OfertaController(OfertaService ofertaService) {
+        this.ofertaService = ofertaService;
+    }
+
+    @GetMapping
+    public List<Oferta> getAll() {
+        return ofertaService.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Oferta> getById(@PathVariable Long id) {
+        return ofertaService.getById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Oferta> create(@RequestBody Oferta oferta) {
+        Oferta saved = ofertaService.save(oferta);
+        return new ResponseEntity<>(saved, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Oferta> update(@PathVariable Long id, @RequestBody Oferta oferta) {
+        Oferta existing = ofertaService.getById(id)
+                .orElseThrow(() -> new RuntimeException("Oferta no encontrada"));
+
+        existing.setNombre(oferta.getNombre());
+        existing.setDescripcion(oferta.getDescripcion());
+        existing.setDescuento(oferta.getDescuento());
+
+        Oferta updated = ofertaService.save(existing);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        ofertaService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{ofertaId}/books/{bookId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Oferta> addBook(@PathVariable Long ofertaId, @PathVariable Long bookId) {
+        Oferta updated = ofertaService.addBook(ofertaId, bookId);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{ofertaId}/books/{bookId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Oferta> removeBook(@PathVariable Long ofertaId, @PathVariable Long bookId) {
+        Oferta updated = ofertaService.removeBook(ofertaId, bookId);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/api/libreria/model/Oferta.java
+++ b/src/main/java/com/api/libreria/model/Oferta.java
@@ -1,0 +1,31 @@
+package com.api.libreria.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name = "ofertas")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Oferta {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nombre;
+
+    private String descripcion;
+
+    private Double descuento;
+
+    @ManyToMany
+    @JoinTable(name = "oferta_books",
+            joinColumns = @JoinColumn(name = "oferta_id"),
+            inverseJoinColumns = @JoinColumn(name = "book_id"))
+    private List<Book> books;
+}

--- a/src/main/java/com/api/libreria/repository/OfertaRepository.java
+++ b/src/main/java/com/api/libreria/repository/OfertaRepository.java
@@ -1,0 +1,7 @@
+package com.api.libreria.repository;
+
+import com.api.libreria.model.Oferta;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OfertaRepository extends JpaRepository<Oferta, Long> {
+}

--- a/src/main/java/com/api/libreria/security/SecurityConfig.java
+++ b/src/main/java/com/api/libreria/security/SecurityConfig.java
@@ -29,7 +29,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/ofertas/**").permitAll()
                 .requestMatchers("/api/books/**").hasRole("ADMIN")
+                .requestMatchers("/api/ofertas/**").hasRole("ADMIN")
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated())
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/api/libreria/service/OfertaService.java
+++ b/src/main/java/com/api/libreria/service/OfertaService.java
@@ -1,0 +1,65 @@
+package com.api.libreria.service;
+
+import com.api.libreria.model.Book;
+import com.api.libreria.model.Oferta;
+import com.api.libreria.repository.BookRepository;
+import com.api.libreria.repository.OfertaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class OfertaService {
+
+    private final OfertaRepository ofertaRepository;
+    private final BookRepository bookRepository;
+
+    public OfertaService(OfertaRepository ofertaRepository, BookRepository bookRepository) {
+        this.ofertaRepository = ofertaRepository;
+        this.bookRepository = bookRepository;
+    }
+
+    public List<Oferta> getAll() {
+        return ofertaRepository.findAll();
+    }
+
+    public Optional<Oferta> getById(Long id) {
+        return ofertaRepository.findById(id);
+    }
+
+    public Oferta save(Oferta oferta) {
+        return ofertaRepository.save(oferta);
+    }
+
+    public void delete(Long id) {
+        ofertaRepository.deleteById(id);
+    }
+
+    public Oferta addBook(Long ofertaId, Long bookId) {
+        Oferta oferta = ofertaRepository.findById(ofertaId)
+                .orElseThrow(() -> new RuntimeException("Oferta no encontrada"));
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new RuntimeException("Libro no encontrado"));
+
+        if (oferta.getBooks() == null) {
+            oferta.setBooks(new ArrayList<>());
+        }
+
+        if (!oferta.getBooks().contains(book)) {
+            oferta.getBooks().add(book);
+        }
+        return ofertaRepository.save(oferta);
+    }
+
+    public Oferta removeBook(Long ofertaId, Long bookId) {
+        Oferta oferta = ofertaRepository.findById(ofertaId)
+                .orElseThrow(() -> new RuntimeException("Oferta no encontrada"));
+
+        if (oferta.getBooks() != null) {
+            oferta.getBooks().removeIf(b -> b.getId().equals(bookId));
+        }
+        return ofertaRepository.save(oferta);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Oferta` entity and repository
- implement service layer for offers
- add CRUD controller with endpoints to manage offers and assign books
- expose `/api/ofertas` paths in security configuration

## Testing
- `./mvnw -q test` *(fails: Failed to fetch from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_685371bd6f5483259804553233a4022e