### PR TITLE
Enable paging and add global error handling

### DIFF
--- a/src/main/java/com/api/libreria/controller/BookController.java
+++ b/src/main/java/com/api/libreria/controller/BookController.java
@@ -3,11 +3,11 @@ package com.api.libreria.controller;
 import com.api.libreria.model.Book;
 import com.api.libreria.repository.BookRepository;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/books")
@@ -20,8 +20,8 @@ public class BookController {
     }
 
     @GetMapping
-    public List<Book> getAllBooks() {
-        return bookRepository.findAll();
+    public Page<Book> getAllBooks(Pageable pageable) {
+        return bookRepository.findAll(pageable);
     }
 
     @PostMapping

--- a/src/main/java/com/api/libreria/controller/CategoriaController.java
+++ b/src/main/java/com/api/libreria/controller/CategoriaController.java
@@ -2,11 +2,11 @@ package com.api.libreria.controller;
 
 import com.api.libreria.model.Categoria;
 import com.api.libreria.repository.CategoriaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/categorias")
@@ -19,8 +19,8 @@ public class CategoriaController {
     }
 
     @GetMapping
-    public List<Categoria> getAll() {
-        return categoriaRepository.findAll();
+    public Page<Categoria> getAll(Pageable pageable) {
+        return categoriaRepository.findAll(pageable);
     }
 
     @PostMapping

--- a/src/main/java/com/api/libreria/controller/EditorialController.java
+++ b/src/main/java/com/api/libreria/controller/EditorialController.java
@@ -2,11 +2,11 @@ package com.api.libreria.controller;
 
 import com.api.libreria.model.Editorial;
 import com.api.libreria.repository.EditorialRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/editoriales")
@@ -19,8 +19,8 @@ public class EditorialController {
     }
 
     @GetMapping
-    public List<Editorial> getAll() {
-        return editorialRepository.findAll();
+    public Page<Editorial> getAll(Pageable pageable) {
+        return editorialRepository.findAll(pageable);
     }
 
     @PostMapping

--- a/src/main/java/com/api/libreria/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/libreria/controller/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.api.libreria.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNotFound(NoSuchElementException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class, RuntimeException.class})
+    public ResponseEntity<String> handleBadRequest(RuntimeException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGeneric(Exception ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/api/libreria/controller/OrderController.java
+++ b/src/main/java/com/api/libreria/controller/OrderController.java
@@ -2,10 +2,10 @@ package com.api.libreria.controller;
 
 import com.api.libreria.model.Order;
 import com.api.libreria.service.OrderService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -24,7 +24,7 @@ public class OrderController {
     }
 
     @GetMapping
-    public List<Order> getAllOrders() {
-        return orderService.getAllOrders();
+    public Page<Order> getAllOrders(Pageable pageable) {
+        return orderService.getAllOrders(pageable);
     }
 }

--- a/src/main/java/com/api/libreria/controller/UserController.java
+++ b/src/main/java/com/api/libreria/controller/UserController.java
@@ -2,10 +2,10 @@ package com.api.libreria.controller;
 
 import com.api.libreria.model.User;
 import com.api.libreria.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
@@ -18,8 +18,8 @@ public class UserController {
     }
 
     @GetMapping
-    public List<User> getAllUsers() {
-        return userService.getAllUsers();
+    public Page<User> getAllUsers(Pageable pageable) {
+        return userService.getAllUsers(pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/api/libreria/controller/VentaController.java
+++ b/src/main/java/com/api/libreria/controller/VentaController.java
@@ -4,13 +4,13 @@ import com.api.libreria.model.Venta;
 import com.api.libreria.repository.UserRepository;
 import com.api.libreria.repository.VentaRepository;
 import com.api.libreria.service.VentaService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/ventas")
@@ -36,9 +36,10 @@ public class VentaController {
     }
 
     @GetMapping
-    public List<Venta> getVentas(@AuthenticationPrincipal UserDetails userDetails) {
+    public Page<Venta> getVentas(@AuthenticationPrincipal UserDetails userDetails,
+                                 Pageable pageable) {
         Long userId = getUserId(userDetails.getUsername());
-        return ventaRepository.findByUsuarioId(userId);
+        return ventaRepository.findByUsuarioId(userId, pageable);
     }
 
     private Long getUserId(String username) {

--- a/src/main/java/com/api/libreria/repository/VentaRepository.java
+++ b/src/main/java/com/api/libreria/repository/VentaRepository.java
@@ -1,11 +1,11 @@
 package com.api.libreria.repository;
 
 import com.api.libreria.model.Venta;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface VentaRepository extends JpaRepository<Venta, Long> {
 
-    List<Venta> findByUsuarioId(Long usuarioId);
+    Page<Venta> findByUsuarioId(Long usuarioId, Pageable pageable);
 }

--- a/src/main/java/com/api/libreria/service/OrderService.java
+++ b/src/main/java/com/api/libreria/service/OrderService.java
@@ -2,11 +2,12 @@ package com.api.libreria.service;
 
 import com.api.libreria.model.*;
 import com.api.libreria.repository.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 public class OrderService {
@@ -66,7 +67,7 @@ public class OrderService {
         return order;
     }
 
-    public List<Order> getAllOrders() {
-        return orderRepository.findAll();
+    public Page<Order> getAllOrders(Pageable pageable) {
+        return orderRepository.findAll(pageable);
     }
 }

--- a/src/main/java/com/api/libreria/service/UserService.java
+++ b/src/main/java/com/api/libreria/service/UserService.java
@@ -2,9 +2,10 @@ package com.api.libreria.service;
 
 import com.api.libreria.model.User;
 import com.api.libreria.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -16,8 +17,8 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    public Page<User> getAllUsers(Pageable pageable) {
+        return userRepository.findAll(pageable);
     }
 
     public Optional<User> getUserById(Long id) {


### PR DESCRIPTION
## Summary
- allow `/api/books` to accept Pageable for pagination
- allow `/api/categorias` to accept Pageable for pagination
- allow `/api/editoriales` to accept Pageable for pagination
- add paging to `/api/orders`, `/api/users`, and `/api/ventas`
- introduce `GlobalExceptionHandler` for standardized 400/404/500 responses

## Testing
- `./mvnw -q test` *(fails: failed to fetch Maven because the environment has no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685371be8dc8832592ea3b2fbf0b2963