### PR TITLE
Allow cart endpoints for guests

### DIFF
--- a/src/main/java/com/api/libreria/controller/CartController.java
+++ b/src/main/java/com/api/libreria/controller/CartController.java
@@ -5,21 +5,21 @@ import com.api.libreria.repository.*;
 import org.springframework.http.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RestController
 @RequestMapping("/api/cart")
-// Allow access to regular users and admins
-@PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
 public class CartController {
 
     private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
+    private final Map<String, Cart> guestCarts = new ConcurrentHashMap<>();
+    private long guestItemIdCounter = 1;
 
     public CartController(CartRepository cartRepository, CartItemRepository cartItemRepository,
                           BookRepository bookRepository, UserRepository userRepository) {
@@ -31,102 +31,203 @@ public class CartController {
 
     // GET carrito actual
     @GetMapping
-    public ResponseEntity<Cart> getCart(@AuthenticationPrincipal UserDetails userDetails) {
-        Long userId = getUserId(userDetails.getUsername());
+    public ResponseEntity<Cart> getCart(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (userDetails != null) {
+            Long userId = getUserId(userDetails.getUsername());
 
-        Cart cart = cartRepository.findByUsuarioId(userId).orElseGet(() -> {
-            Cart newCart = new Cart();
-            newCart.setUsuarioId(userId);
-            return cartRepository.save(newCart);
-        });
+            Cart cart = cartRepository.findByUsuarioId(userId).orElseGet(() -> {
+                Cart newCart = new Cart();
+                newCart.setUsuarioId(userId);
+                return cartRepository.save(newCart);
+            });
 
-        return ResponseEntity.ok(cart);
+            return ResponseEntity.ok(cart);
+        }
+
+        Cart cart = sessionId != null ? guestCarts.get(sessionId) : null;
+        if (cart == null) {
+            cart = new Cart();
+            cart.setItems(new ArrayList<>());
+            if (sessionId == null) {
+                sessionId = UUID.randomUUID().toString();
+            }
+            guestCarts.put(sessionId, cart);
+        }
+        return ResponseEntity.ok()
+                .header("X-Session-Id", sessionId)
+                .body(cart);
     }
 
     // POST agregar libro al carrito
     @PostMapping("/add")
     public ResponseEntity<Cart> addToCart(@AuthenticationPrincipal UserDetails userDetails,
                                           @RequestParam Long bookId,
-                                          @RequestParam Integer cantidad) {
+                                          @RequestParam Integer cantidad,
+                                          @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
 
-        Long userId = getUserId(userDetails.getUsername());
-        Cart cart = cartRepository.findByUsuarioId(userId).orElseGet(() -> {
-            Cart newCart = new Cart();
-            newCart.setUsuarioId(userId);
-            return cartRepository.save(newCart);
-        });
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new RuntimeException("Libro no encontrado"));
 
-        Book book = bookRepository.findById(bookId).orElseThrow(() -> new RuntimeException("Libro no encontrado"));
+        if (userDetails != null) {
+            Long userId = getUserId(userDetails.getUsername());
+            Cart cart = cartRepository.findByUsuarioId(userId).orElseGet(() -> {
+                Cart newCart = new Cart();
+                newCart.setUsuarioId(userId);
+                return cartRepository.save(newCart);
+            });
 
-        // Buscamos si el item ya existe en el carrito
-        Optional<CartItem> existingItem = cart.getItems() == null ? Optional.empty() :
-            cart.getItems().stream().filter(item -> item.getBook().getId().equals(bookId)).findFirst();
+            Optional<CartItem> existingItem = cart.getItems() == null ? Optional.empty() :
+                    cart.getItems().stream().filter(item -> item.getBook().getId().equals(bookId)).findFirst();
+
+            if (existingItem.isPresent()) {
+                CartItem item = existingItem.get();
+                item.setCantidad(item.getCantidad() + cantidad);
+                cartItemRepository.save(item);
+            } else {
+                CartItem item = new CartItem();
+                item.setBook(book);
+                item.setCantidad(cantidad);
+                item.setPrecioUnitario(book.getPrice());
+                item.setCart(cart);
+                cartItemRepository.save(item);
+            }
+
+            cart = cartRepository.findByUsuarioId(userId).get();
+            return ResponseEntity.ok(cart);
+        }
+
+        Cart cart = sessionId != null ? guestCarts.get(sessionId) : null;
+        if (cart == null) {
+            cart = new Cart();
+            cart.setItems(new ArrayList<>());
+            if (sessionId == null) {
+                sessionId = UUID.randomUUID().toString();
+            }
+            guestCarts.put(sessionId, cart);
+        }
+
+        Optional<CartItem> existingItem = cart.getItems().stream()
+                .filter(item -> item.getBook().getId().equals(bookId))
+                .findFirst();
 
         if (existingItem.isPresent()) {
             CartItem item = existingItem.get();
             item.setCantidad(item.getCantidad() + cantidad);
-            cartItemRepository.save(item);
         } else {
             CartItem item = new CartItem();
+            item.setId(guestItemIdCounter++);
             item.setBook(book);
             item.setCantidad(cantidad);
             item.setPrecioUnitario(book.getPrice());
-            item.setCart(cart);
-            cartItemRepository.save(item);
+            if (cart.getItems() == null) {
+                cart.setItems(new ArrayList<>());
+            }
+            cart.getItems().add(item);
         }
 
-        cart = cartRepository.findByUsuarioId(userId).get();
-        return ResponseEntity.ok(cart);
+        guestCarts.put(sessionId, cart);
+        return ResponseEntity.ok()
+                .header("X-Session-Id", sessionId)
+                .body(cart);
     }
 
     // PUT actualizar cantidad de un item
     @PutMapping("/items/{itemId}")
     public ResponseEntity<Cart> updateItemQuantity(@AuthenticationPrincipal UserDetails userDetails,
                                                    @PathVariable Long itemId,
-                                                   @RequestParam Integer cantidad) {
-        Long userId = getUserId(userDetails.getUsername());
+                                                   @RequestParam Integer cantidad,
+                                                   @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (userDetails != null) {
+            Long userId = getUserId(userDetails.getUsername());
 
-        Cart cart = cartRepository.findByUsuarioId(userId)
-                .orElseThrow(() -> new RuntimeException("Carrito no encontrado"));
+            Cart cart = cartRepository.findByUsuarioId(userId)
+                    .orElseThrow(() -> new RuntimeException("Carrito no encontrado"));
 
-        CartItem item = cartItemRepository.findById(itemId)
-                .orElseThrow(() -> new RuntimeException("Item no encontrado"));
+            CartItem item = cartItemRepository.findById(itemId)
+                    .orElseThrow(() -> new RuntimeException("Item no encontrado"));
 
-        if (!item.getCart().getId().equals(cart.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            if (!item.getCart().getId().equals(cart.getId())) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+
+            if (cantidad <= 0) {
+                cartItemRepository.delete(item);
+            } else {
+                item.setCantidad(cantidad);
+                cartItemRepository.save(item);
+            }
+
+            cart = cartRepository.findByUsuarioId(userId).orElse(cart);
+            return ResponseEntity.ok(cart);
         }
 
+        Cart cart = sessionId != null ? guestCarts.get(sessionId) : null;
+        if (cart == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Optional<CartItem> optItem = cart.getItems().stream()
+                .filter(i -> i.getId().equals(itemId))
+                .findFirst();
+        if (optItem.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        CartItem item = optItem.get();
         if (cantidad <= 0) {
-            cartItemRepository.delete(item);
+            cart.getItems().remove(item);
         } else {
             item.setCantidad(cantidad);
-            cartItemRepository.save(item);
         }
 
-        cart = cartRepository.findByUsuarioId(userId).orElse(cart);
-        return ResponseEntity.ok(cart);
+        guestCarts.put(sessionId, cart);
+        return ResponseEntity.ok()
+                .header("X-Session-Id", sessionId)
+                .body(cart);
     }
 
     // DELETE eliminar item del carrito
     @DeleteMapping("/items/{itemId}")
     public ResponseEntity<Cart> removeItem(@AuthenticationPrincipal UserDetails userDetails,
-                                           @PathVariable Long itemId) {
-        Long userId = getUserId(userDetails.getUsername());
+                                           @PathVariable Long itemId,
+                                           @RequestHeader(value = "X-Session-Id", required = false) String sessionId) {
+        if (userDetails != null) {
+            Long userId = getUserId(userDetails.getUsername());
 
-        Cart cart = cartRepository.findByUsuarioId(userId)
-                .orElseThrow(() -> new RuntimeException("Carrito no encontrado"));
+            Cart cart = cartRepository.findByUsuarioId(userId)
+                    .orElseThrow(() -> new RuntimeException("Carrito no encontrado"));
 
-        CartItem item = cartItemRepository.findById(itemId)
-                .orElseThrow(() -> new RuntimeException("Item no encontrado"));
+            CartItem item = cartItemRepository.findById(itemId)
+                    .orElseThrow(() -> new RuntimeException("Item no encontrado"));
 
-        if (!item.getCart().getId().equals(cart.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            if (!item.getCart().getId().equals(cart.getId())) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+
+            cartItemRepository.delete(item);
+
+            cart = cartRepository.findByUsuarioId(userId).orElse(cart);
+            return ResponseEntity.ok(cart);
         }
 
-        cartItemRepository.delete(item);
+        Cart cart = sessionId != null ? guestCarts.get(sessionId) : null;
+        if (cart == null) {
+            return ResponseEntity.notFound().build();
+        }
 
-        cart = cartRepository.findByUsuarioId(userId).orElse(cart);
-        return ResponseEntity.ok(cart);
+        Optional<CartItem> optItem = cart.getItems().stream()
+                .filter(i -> i.getId().equals(itemId))
+                .findFirst();
+        if (optItem.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        cart.getItems().remove(optItem.get());
+        guestCarts.put(sessionId, cart);
+        return ResponseEntity.ok()
+                .header("X-Session-Id", sessionId)
+                .body(cart);
     }
 
     private Long getUserId(String username) {

--- a/src/main/java/com/api/libreria/security/SecurityConfig.java
+++ b/src/main/java/com/api/libreria/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/ofertas/**").permitAll()
+                .requestMatchers("/api/cart/**").permitAll()
                 // rutas protegidas
                 .requestMatchers("/api/books/**").hasRole("ADMIN")
                 .requestMatchers("/api/ofertas/**").hasRole("ADMIN")


### PR DESCRIPTION
## Summary
- update security configuration to permit `/api/cart/**`
- remove role restriction on `CartController`
- allow unauthenticated users by managing guest carts with a session header

## Testing
- `./mvnw -q test` *(fails: Failed to fetch because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68538d0848e48325aa84e11aa77186a5